### PR TITLE
[FIX] fix gameover bug

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -9,19 +9,18 @@ import { Tools } from './tools.js';
 keypress(process.stdin);
 
 
-async function selectOption(logs, stage, player, monster, options) {
+async function selectOption(logs, player, monster, options) {
     let index = 0;
 
     let printValues = {
         _logs: logs,
-        _stage: stage,
         _player: player,
         _monster: monster
     }
 
 
     //기존 로그 출력
-    displayScreen(logs, stage, player, monster);
+    displayScreen(logs, player, monster);
 
     //옵션 출력
     renderOptions(options, index);
@@ -40,11 +39,11 @@ function select(values, options, selectedIndex) {
             if (key) {
                 if (key.name === "up" || key.name === "w") {
                     selectedIndex = (selectedIndex - 1 + options.length) % options.length;
-                    displayScreen(values._logs, values._stage, values._player, values._monster);
+                    displayScreen(values._logs, values._player, values._monster);
                     renderOptions(options, selectedIndex);
                 } else if (key.name === "down" || key.name === "s") {
                     selectedIndex = (selectedIndex + 1) % options.length;
-                    displayScreen(values._logs, values._stage, values._player, values._monster);
+                    displayScreen(values._logs, values._player, values._monster);
                     renderOptions(options, selectedIndex);
                 } else if (key.name === "return") {
 
@@ -84,18 +83,18 @@ function renderOptions(options, selectedIndex) {
 
 
 
-function displayScreen(logs, stage, player, monster) {
+function displayScreen(logs, player, monster) {
     console.clear();
-    displayStatus(stage, player, monster);
+    displayStatus(player, monster);
     logs.forEach((log) => console.log(log));
 }
 
 
 
 // #region 정보 보여주기
-function displayStatus(stage, player, monster) {
+function displayStatus( player, monster) {
     console.log(chalk.magentaBright(`\n=== Current Status ===`));
-    console.log(chalk.cyanBright(`| Stage: ${stage} |\n`));
+    console.log(chalk.cyanBright(`| Stage: ${GameManager.currentStage} |\n`));
     console.log(chalk.blueBright(
         `
 | 플레이어 정보
@@ -121,7 +120,7 @@ function displayStatus(stage, player, monster) {
 
 // #endregion
 
-const battle = async (stage, player, monster) => {
+const battle = async (player, monster) => {
 
     let logs = [];
 
@@ -132,7 +131,7 @@ const battle = async (stage, player, monster) => {
     while (!GameManager.isGameOver) {
         //console.clear();
 
-        displayScreen(logs, stage, player, monster);
+        displayScreen(logs, player, monster);
 
         // 탈출 체크
         if (player.isDead) {
@@ -155,7 +154,7 @@ const battle = async (stage, player, monster) => {
 
         let actions = ['1. 공격한다.', '2. 도망간다.'];
 
-        const choice = await selectOption(logs, stage, player, monster, actions);
+        const choice = await selectOption(logs, player, monster, actions);
 
         logs = [];
 
@@ -225,19 +224,21 @@ async function handleUserInput(logs, choice, player, monster) {
 
 
 // 게임 시작
-export async function battleLoop(stage, num, player) {
+export async function battleLoop( num, player) {
     console.clear();
+
+    const stage = GameManager.currentStage;
 
     let hasWon = true;
     for (let i = 0; i < num; i++) {
         const monster = new Monster(stage);
-        let hasWon = await battle(stage, player, monster);
+        let hasWon = await battle(player, monster);
 
         //GameOver
         if (GameManager.isGameOver) {
-            GameManager.isGameOver = false;
+            GameManager.isGameOver = true;
             player.isDead = false;
-            start();
+            return;
         }
 
         // 플레이어 체력 회복

--- a/js/game.js
+++ b/js/game.js
@@ -5,6 +5,8 @@ import { Point } from './map.js';
 import { Tools } from './tools.js';
 import chalk from 'chalk';
 import { battleLoop } from './battle.js';
+import { GameManager } from './gameManager.js';
+import { start } from './server.js';
 
 keypress(process.stdin);
 
@@ -18,8 +20,6 @@ function move(board, arr, dx, dy, player) {
     arr[player.x][player.y] = '●';
 
     const res = drawMap(board, arr, player.x, player.y);
-
-    printBoard(arr);
 
     return res;
 }
@@ -62,33 +62,29 @@ function drawMap(board, arr, x, y) {
 }
 
 // 이동 입력하기
-function userMoveInput(stage, board, arr, player) {
+function userMoveInput(board, arr, player) {
 
     let loc = player.loc;
 
     return new Promise((resolve) => {
         async function handleMoveInput(ch, key) {
-            //console.log(key.name);
+            console.log("move : ", key.name);
             if (key) {
                 if (key.name === "up" || key.name === "w") { //위로 가기
                     //분기 처리
-                    InputHandler(stage, board, arr, player, -1, 0);
-
+                    await inputHandler(board, arr, player, -1, 0);
                     resolve(true);
                 } else if (key.name === "down" || key.name === "s") { //아래로 가기
                     //분기 처리
-                    InputHandler(stage, board, arr, player, 1, 0);
-
+                    await inputHandler(board, arr, player, 1, 0);
                     resolve(true);
                 } else if (key.name === "left" || key.name === "a") { //왼쪽으로 가기
                     //분기 처리
-                    InputHandler(stage, board, arr, player, 0, -1);
-                    
+                    await inputHandler(board, arr, player, 0, -1);
                     resolve(true);
                 } else if (key.name === "right" || key.name === "d") { //오른쪽으로 가기
                     //분기 처리
-                    InputHandler(stage, board, arr, player, 0, 1);
-
+                    await inputHandler(board, arr, player, 0, 1);
                     resolve(true);
                 } else if (key.ctrl && key.name === "c") {
                     process.exit();
@@ -108,24 +104,23 @@ function userMoveInput(stage, board, arr, player) {
             process.stdin.removeListener("keypress", handleMoveInput); // 이벤트 리스너 제거
         }
 
-        const InputHandler = async (stage, board, arr, player, dx, dy) => {
+        const inputHandler = async (board, arr, player, dx, dy) => {
+            // 이벤트 삭제
+            deleteInput();
             switch (checkTile(board, loc.x + dx, loc.y + dy)) {
                 case 'space':
-                    const res = await move(board, arr, dx, dy, loc);
+                    const res = move(board, arr, dx, dy, loc);
+                    console.log(res);
                     if (res.length > 0) {
-                        // 이벤트 삭제
-                        deleteInput();
-
+                        
                         //battle 로그
-                        meetMonster(stage, board, arr, res, player);
+                        await meetMonster(board, arr, res, player);
                     }
                     break;
                 case 'stairs':
-                    // 이벤트 삭제
-                    deleteInput();
 
                     //다음 스테이지로 이동
-                    selectStageClear(stage, board, arr, player);
+                    await selectStageClear(arr);
 
                     break;
             }
@@ -135,13 +130,18 @@ function userMoveInput(stage, board, arr, player) {
 }
 
 // #region 분기 처리
-const meetMonster = async (stage, board, map, monsters, player) => {
+const meetMonster = async (board, map, monsters, player) => {
+
+    printBoard(map);
+
     console.log(chalk.red(`몬스터를 발견했어요!`));
 
     console.log(chalk.gray(`엔터를 눌러주세요.`));
-    await Tools.confirmInput();
+    const confirm = await Tools.confirmInput();
 
-    const res = await battleLoop(stage, monsters.length, player);
+    console.log(confirm);
+
+    const res = await battleLoop(monsters.length, player);
 
     if (res) {
         for (const item of monsters) {
@@ -149,8 +149,6 @@ const meetMonster = async (stage, board, map, monsters, player) => {
             board[item.x][item.y] = '·';
         }
     }
-
-    game(stage, player, board, map);
 }
 
 
@@ -222,14 +220,12 @@ function select(arr, options, selectedIndex) {
 
 }
 
-const selectStageClear = async (stage, board, map, player) => {
+const selectStageClear = async (map) => {
 
     const flag = await selectStage(map);
 
     if (flag) {
-        newStage(stage + 1, player);
-    } else {
-        game(stage, player, board, map);
+        GameManager.currentStage += 1;
     }
 
 }
@@ -239,28 +235,50 @@ const selectStageClear = async (stage, board, map, player) => {
 // #endregion 
 
 // 스테이지 시작 
-async function newStage(stage, player) {
+function newStage(player) {
     // 맵 생성
-    const board = generateMap(player.loc);
+    const _board = generateMap(player.loc);
 
     // 시야 맵
-    let map = Array.from(new Array(board.length), () => new Array(board[0].length).fill(' '));
+    let _map = Array.from(new Array(_board.length), () => new Array(_board[0].length).fill(' '));
 
     //처음 맵 그리기
-    drawMap(board, map, player.loc.x, player.loc.y);
-    map[player.loc.x][player.loc.y] = '●';
+    drawMap(_board, _map, player.loc.x, player.loc.y);
+    _map[player.loc.x][player.loc.y] = '●';
 
-    game(stage, player, board, map);
+    return {
+        board: _board,
+        map: _map
+    }
 }
 
 
 
 // gameLoop
-async function game(stage, player, board, map) {
+async function game(stage, player) {
 
-    printBoard(map);
+    while (!GameManager.isGameOver) {
 
-    await userMoveInput(stage, board, map, player);
+        //스테이지 초기화
+        stage = GameManager.currentStage;
+
+        //새로운 스테이지 생성
+        let { board, map } = newStage(player);
+
+        while (!GameManager.isGameOver && GameManager.currentStage === stage) {
+
+            //맵 그리기
+            printBoard(map);
+
+            console.log('loop');
+
+            //입력 처리
+            await userMoveInput(board, map, player);
+        }
+    }
+
+    //게임 오버 하면
+    start();
 }
 
 
@@ -272,5 +290,5 @@ export async function startGame() {
     //현재 스테이지
     let stage = 1;
 
-    newStage(stage, player);
+    game(stage, player);
 }

--- a/js/gameManager.js
+++ b/js/gameManager.js
@@ -1,3 +1,4 @@
 export class GameManager {
     static isGameOver = false;
+    static currentStage = 1;
 }

--- a/js/map.js
+++ b/js/map.js
@@ -253,7 +253,6 @@ function getRoomLoc(arr, room) {
 
 //오브젝트 위치 정하기
 function spawnObjects(arr, rooms, player) {
-
     //몬스터 수 정하기
     let monsterCnt = Tools.getRandomNum(MIN_MONSTER, MAX_MONSTER);
 
@@ -315,9 +314,6 @@ function spawnObjects(arr, rooms, player) {
 
 //BSP 알고리즘
 function BSP(arr, player) {
-
-    console.clear();
-
     const root = new Container(0, 0, MAP_WIDTH, MAP_HEIGHT);
 
     //범위 나누고 길 만들기
@@ -352,7 +348,7 @@ function BSP(arr, player) {
 
 //화면 출력
 export function printBoard(arr) {
-    console.clear();
+    //console.clear();
 
     for (let row of arr) {
         let text = '';
@@ -367,9 +363,8 @@ export function printBoard(arr) {
 
 export function generateMap(player) {
     let arr = Array.from(new Array(MAP_HEIGHT), () => new Array(MAP_WIDTH).fill('%'));
-
+    
     //BSP 알고리즘 실행
     BSP(arr, player);
-
     return arr;
 }

--- a/js/monster.js
+++ b/js/monster.js
@@ -5,7 +5,7 @@ export class Monster {
         this._level = stage;
         this._isDead = false;
         this._hp = 60 + (10 * (stage - 1));
-        this._minDamage = 2 + (5 * (stage - 1));
+        this._minDamage = 12 + (5 * (stage - 1));
         this._maxDamage = 12 + (5 * (stage - 1));
         this._speed = 5;
         this._equipment = {};       // 장비 칸

--- a/js/player.js
+++ b/js/player.js
@@ -7,7 +7,7 @@ export class Player {
         this._level = 1;
         this._isDead = false;
         this._MaxHP = 100;
-        this._hp = 100;
+        this._hp = 20;
         this._minDamage = 5;
         this._maxDamage = 10;
         this._speed = 5;

--- a/js/server.js
+++ b/js/server.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import figlet from 'figlet';
 import { startGame } from "./game.js";
 import keypress from 'keypress';
+import { GameManager } from './gameManager.js';
 
 keypress(process.stdin);
 
@@ -159,6 +160,9 @@ function printLog(logs) {
 
 // 게임 시작 함수
 export async function start() {
+
+    GameManager.isGameOver = false;
+    GameManager.currentStage = 1;
     let logs = { color: '', text: '' };
     let actions = [' 새로운 게임 시작', ' 업적 확인하기', ' 옵션', ' 종료'];
 

--- a/js/tools.js
+++ b/js/tools.js
@@ -8,9 +8,11 @@ export class Tools {
     static confirmInput() {
         return new Promise((resolve) => {
             function handleConfirmInput(ch, key) {
+
+                console.log("confirm : ", key);
                 if (key) {
                     if (key.name === "return") {
-    
+
                         //입력 설정(입력 이벤트 제거)
                         process.stdin.setRawMode(false);
                         process.stdin.pause();
@@ -21,12 +23,12 @@ export class Tools {
                     }
                 }
             }
-    
+
             // 입력 설정
             process.stdin.on("keypress", handleConfirmInput);
             process.stdin.setRawMode(true);
             process.stdin.resume();
-    
+
         })
     }
 }


### PR DESCRIPTION
게임 오버 버그 생성

문제 : 게임 오버가 되면 메인으로 갔다가 다시 맵이 나오고 이동하다가 다시 메인으로 돌아가는 등 이상하게 작동했다.

동기/비동기 와 함수 호출에서 로직이 꼬여서 생기는 문제 같아서 console.clear()를 멈추고 확인.

코드를 짜면서 메인 게임 루프를 도는 방식이 아닌 건 인지한 상태여서 루프 형태로 바꿨다. 
그리고 현재 stage를 GameManager에 넣어서 스테이지 변경시점을 정했다.

이렇게 바꾸니 생긴 문제가 입력 중복 현상.
이동에 있어서 이벤트를 삭제하지 않고 계속 실행을 해서 이벤트 leak 에러가 나왔다. 그래서 분기마다 다 삭제했다.

그리고 또 문제를 발견했는데 진행에 있어서 큰 문제는 아니지만 맵이 두 번 출력되는 문제가 있었다. console.clear()로 버그가 보이지 않고 있었다. 이도 해결했다.

정리하자면 버그는 다음과 같다.

1. 메인 루프를 사용하지 않아 게임 로직이 꼬임.
2. 입력 중복 현상
3. 맵 중복 출력 현상
